### PR TITLE
fix: [200~28:26  Error: React Hook usePathname cannot be called insi…

### DIFF
--- a/nextjs-dashboard/app/ui/dashboard/nav-links.tsx
+++ b/nextjs-dashboard/app/ui/dashboard/nav-links.tsx
@@ -22,10 +22,11 @@ const links = [
 ];
 
 export default function NavLinks() {
+  const pathname = usePathname();
   return (
     <>
       {links.map((link) => {
-        const pathname = usePathname();
+        // const pathname = usePathname();
         const LinkIcon = link.icon;
         return (
           <Link


### PR DESCRIPTION
…de a callback. React Hooks must be called in a React function component or a custom React Hook function.  react-hooks/rules-of-hooks~